### PR TITLE
Add invariant ratio estimator

### DIFF
--- a/labelshift/algorithms/bbse.py
+++ b/labelshift/algorithms/bbse.py
@@ -50,7 +50,7 @@ def from_sufficient_statistic(
 
     Args:
         n_y_and_c_labeled: the (l, k)th entry contains the number of examples
-          in the labeled data set such that Y = l and C=(f(X)) = k. Shape (L, K)
+          in the labeled data set such that Y = l and C= f(X) = k. Shape (L, K)
         n_c_unlabeled: the `k`th entry contains the number of examples in the
           unlabeled data set such that Y = k. Shape (K,)
         p_y_labeled: the Y prevalence vector in the labeled data set, shape (L,).

--- a/labelshift/algorithms/ratio_estimator.py
+++ b/labelshift/algorithms/ratio_estimator.py
@@ -1,0 +1,6 @@
+"""Implements the ratio estimator described in:
+
+Afonso Fernandes Vaz, Rafael Izbicki, Rafael Bassi Stern;
+Quantification Under Prior Probability Shift: the Ratio Estimator and its Extensions
+Journal of Machine Learning Research, 20(79):1−33, 2019.
+"""

--- a/labelshift/algorithms/ratio_estimator.py
+++ b/labelshift/algorithms/ratio_estimator.py
@@ -3,4 +3,164 @@
 Afonso Fernandes Vaz, Rafael Izbicki, Rafael Bassi Stern;
 Quantification Under Prior Probability Shift: the Ratio Estimator and its Extensions
 Journal of Machine Learning Research, 20(79):1−33, 2019.
+
+More precisely, we implemented the estimator from Remark 5 on page 5
+using a bit different notation.
+
+Consider the true label ``Y \\in \\{1, ..., L\\}`` and a given function
+
+  ``f: X --> R^K``.
+
+In the paper there is a requirement ``K=L``, although we will not strictly enforce it
+in this implementation.
+
+Then, a projection of ``f`` onto the first ``K-1`` components is constructed:
+
+  ``g: X --> R^{K-1}``
+
+and the following vector is constructed
+
+ ``g_hat[k] = E_unlabeled[ g(X)[k] ] \\in R^{K-1}``
+
+as well as the following matrix
+
+  ``G_hat[k, l] = E_labeled[ g(X)[k]  | Y = l] \\in R^{(K-1) x L}``
+
+If ``y \\in R^L `` is the prevalence vector,
+it is supposed to fulfil the following equations:
+
+  ``
+     g_hat[k] = sum_l( G_hat[k, l] y[l] )
+     sum_l( y[l] ) = 1
+  ``
+
+To make sure it is a probability vector, it can be projected onto the (L-1)-simplex.
+
+According to our conventions, we will use the transpose of this matrix:
+
+  ``H_hat[l, k] = G_hat[l, k] = E_labeled[ g(X)[k]  | Y = l] \\in R^{L x (K-1)}.``
+
 """
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from labelshift.algorithms.bbse import solve_system
+from labelshift.adjustments import project_onto_probability_simplex
+
+
+def prevalence_from_vector_and_matrix(
+    vector: np.ndarray,
+    matrix: np.ndarray,
+    restricted: bool = True,
+    enforce_square: bool = True,
+    rcond: float = 1e-4,
+) -> np.ndarray:
+    """Calculates the prevalence vector from the ``g_hat`` vector
+    and the ``H_hat = transpose(G_hat)`` matrix.
+
+    Args:
+        vector: the ``\\hat g`` vector, shape (K-1,),
+          where K is the number of values C = g(X) can take
+        matrix: shape (L, K-1)
+        enforce_square: whether a square solver should be used.
+          In that case one needs K = L.
+        rcond: parameter of the solver
+        restricted: whether to use restricted or unrestricted estimator
+
+    Returns:
+        estimated prevalence vector, shape (L,)
+    """
+    K = vector.shape[0] + 1
+    L = matrix.shape[0]
+
+    if matrix.shape != (L, K - 1):
+        raise ValueError(
+            f"The matrix has shape {matrix.shape} rather than {(L, K - 1)}."
+        )
+
+    new_vector = np.ones(K, dtype=float)
+    new_vector[:K] = vector
+
+    new_matrix = np.ones((L, K), dtype=float)
+    new_matrix[:, : (K - 1)] = matrix
+
+    unrestricted = solve_system(
+        matrix=new_matrix.T,
+        vector=new_vector,
+        square_solver=enforce_square,
+        rcond=rcond,
+    )
+    if restricted:
+        return project_onto_probability_simplex(unrestricted)
+    else:
+        return unrestricted
+
+
+def calculate_vector_and_matrix_from_predictions(
+    unlabeled_predictions: ArrayLike,
+    labeled_predictions: ArrayLike,
+) -> None:
+    """This method has not been implemented yet."""
+    raise NotImplementedError
+
+
+def calculate_vector_and_matrix_from_summary_statistics(
+    n_c_unlabeled: ArrayLike,
+    n_y_and_c_labeled: ArrayLike,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+
+    Args:
+        n_c_unlabeled: vector of shape (K,)
+        n_y_and_c_labeled: matrix of shape (L, K)
+
+    Returns:
+        vector_c: vector of shape (K-1,)
+        matrix_y_c: matrix of shape (L, K-1)
+    """
+    n_c = np.asarray(n_c_unlabeled, dtype=float)
+    n_y_c = np.asarray(n_y_and_c_labeled, dtype=float)
+
+    if n_y_c.shape[1] != n_c.shape[0]:
+        raise ValueError(
+            f"Shape mismatch: {n_y_c.shape} is not compatible with {n_c.shape}."
+        )
+
+    p_c = n_c / n_c.sum()
+    p_y_c = n_y_c / n_y_c.sum(axis=1)[:, None]
+
+    return p_c[:-1], p_y_c[:, :-1]
+
+
+def prevalence_from_summary_statistics(
+    n_c_unlabeled: ArrayLike,
+    n_y_and_c_labeled: ArrayLike,
+    restricted: bool = True,
+    enforce_square: bool = True,
+    rcond: float = 1e-4,
+) -> np.ndarray:
+    """Estimates the prevalence vector from the sufficient statistic.
+
+    Args:
+        n_c_unlabeled: vector of shape (K,)
+        n_y_and_c_labeled: matrix of shape (L, K)
+        enforce_square: whether a square solver should be used.
+          In that case one needs K = L.
+        rcond: parameter of the solver
+        restricted: whether to use restricted or unrestricted estimator
+
+    Returns:
+        estimated prevalence vector, shape (L,)
+    """
+    vector, matrix = calculate_vector_and_matrix_from_summary_statistics(
+        n_c_unlabeled=n_c_unlabeled, n_y_and_c_labeled=n_y_and_c_labeled
+    )
+    return prevalence_from_vector_and_matrix(
+        vector=vector,
+        matrix=matrix,
+        restricted=restricted,
+        enforce_square=enforce_square,
+        rcond=rcond,
+    )

--- a/labelshift/algorithms/ratio_estimator.py
+++ b/labelshift/algorithms/ratio_estimator.py
@@ -81,7 +81,7 @@ def prevalence_from_vector_and_matrix(
         )
 
     new_vector = np.ones(K, dtype=float)
-    new_vector[:K] = vector
+    new_vector[: K - 1] = vector
 
     new_matrix = np.ones((L, K), dtype=float)
     new_matrix[:, : (K - 1)] = matrix

--- a/tests/algorithms/test_ratio_estimator.py
+++ b/tests/algorithms/test_ratio_estimator.py
@@ -1,0 +1,38 @@
+"""Tests of the Invariant Ratio Estimator algorithm."""
+import numpy as np
+import pytest
+
+import labelshift.algorithms.ratio_estimator as re
+import labelshift.datasets.discrete_categorical as dc
+
+
+@pytest.mark.parametrize("restricted", (True, False))
+def test_ratio_estimator_from_sufficient_statistic(
+    restricted: bool, n_labeled: int = 20_000, n_unlabeled: int = 20_000
+) -> None:
+    """Generates the data according to the P(C|Y) model."""
+    p_y_labeled = np.asarray([0.4, 0.6])
+    p_y_unlabeled = np.asarray([0.7, 0.3])
+
+    p_c_cond_y = np.asarray(
+        [
+            [0.95, 0.04, 0.01],
+            [0.04, 0.95, 0.01],
+        ]
+    )
+
+    sampler = dc.DiscreteSampler(
+        p_y_labeled=p_y_labeled, p_y_unlabeled=p_y_unlabeled, p_c_cond_y=p_c_cond_y
+    )
+    statistic = sampler.sample_summary_statistic(
+        n_labeled=n_labeled, n_unlabeled=n_unlabeled, seed=111
+    )
+
+    p_y_estimated = re.prevalence_from_summary_statistics(
+        n_y_and_c_labeled=statistic.n_y_and_c_labeled,
+        n_c_unlabeled=statistic.n_c_unlabeled,
+        enforce_square=False,
+        restricted=restricted,
+    )
+
+    assert p_y_estimated == pytest.approx(p_y_unlabeled, abs=0.01)

--- a/tests/algorithms/test_ratio_estimator.py
+++ b/tests/algorithms/test_ratio_estimator.py
@@ -7,12 +7,18 @@ import labelshift.datasets.discrete_categorical as dc
 
 
 @pytest.mark.parametrize("restricted", (True, False))
+@pytest.mark.parametrize("p1_labeled", [0.4, 0.8])
+@pytest.mark.parametrize("p1_unlabeled", [0.2, 0.5, 0.9])
 def test_ratio_estimator_from_sufficient_statistic(
-    restricted: bool, n_labeled: int = 20_000, n_unlabeled: int = 20_000
+    restricted: bool,
+    p1_labeled: float,
+    p1_unlabeled: float,
+    n_labeled: int = 20_000,
+    n_unlabeled: int = 20_000,
 ) -> None:
     """Generates the data according to the P(C|Y) model."""
-    p_y_labeled = np.asarray([0.4, 0.6])
-    p_y_unlabeled = np.asarray([0.7, 0.3])
+    p_y_labeled = np.asarray([1 - p1_labeled, p1_labeled])
+    p_y_unlabeled = np.asarray([1 - p1_unlabeled, p1_unlabeled])
 
     p_c_cond_y = np.asarray(
         [


### PR DESCRIPTION
Adds an invariant ratio estimator (generalized a bit, as it doesn't enforce square matrices).

Afonso Fernandes Vaz, Rafael Izbicki, Rafael Bassi Stern, _Quantification Under Prior Probability Shift: the Ratio Estimator and its Extensions_, Journal of Machine Learning Research, 20(79):1−33, 2019.